### PR TITLE
Use ipset module for banning IPs

### DIFF
--- a/playbooks/sec_ipset_ban_ip.yml
+++ b/playbooks/sec_ipset_ban_ip.yml
@@ -1,12 +1,22 @@
 - name: Ban IP on all servers
   hosts: all
   become: true
+  collections:
+    - community.general
   vars:
     ban_ip: "1.2.3.4"
     ban_time: 3600
   tasks:
     - name: Ensure banlist exists with desired timeout
-      command: ipset create banlist hash:ip timeout {{ ban_time }} -exist
+      community.general.ipset:
+        name: banlist
+        state: present
+        set_type: hash:ip
+        timeout: "{{ ban_time }}"
 
     - name: Add IP with timeout (auto-expires)
-      command: ipset add banlist {{ ban_ip }} timeout {{ ban_time }} -exist
+      community.general.ipset:
+        name: banlist
+        entry: "{{ ban_ip }}"
+        state: present
+        timeout: "{{ ban_time }}"


### PR DESCRIPTION
## Summary
- use community.general.ipset module to manage banlist
- add community.general collection to playbook

## Testing
- `ansible-playbook playbooks/sec_ipset_ban_ip.yml --syntax-check` *(fails: couldn't resolve module 'community.general.ipset')*

------
https://chatgpt.com/codex/tasks/task_b_68c6c186073c8322bf27c94be0b44362