### PR TITLE
Reload firewall-restore service unit

### DIFF
--- a/roles/firewall_ipset/handlers/main.yml
+++ b/roles/firewall_ipset/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart firewall-restore service
+  systemd:
+    name: firewall-restore.service
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/firewall_ipset/tasks/main.yml
+++ b/roles/firewall_ipset/tasks/main.yml
@@ -77,10 +77,12 @@
           [Install]
           WantedBy=multi-user.target
       become: true
+      notify: Restart firewall-restore service
 
     - name: Enable service
       systemd:
         name: firewall-restore.service
         enabled: true
         state: started
+        daemon_reload: true
       become: true


### PR DESCRIPTION
## Summary
- reload firewall-restore systemd unit after updates
- restart firewall-restore service when its unit file changes

## Testing
- `ansible-lint roles/firewall_ipset/tasks/main.yml` *(fails: parser-error profile:min tags:core)*
- `ansible-lint playbooks/sec_firewall_ipset_setup.yml` *(fails: syntax-check: 'block' is not a valid attribute for a Play)*
- `ansible-playbook --syntax-check playbooks/sec_firewall_ipset_setup.yml` *(fails: 'block' is not a valid attribute for a Play)*
- `yamllint roles/firewall_ipset/tasks/main.yml roles/firewall_ipset/handlers/main.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c1b7513c8322bf1b8c73936af13b