### PR TITLE
Use Ansible facts for node health report

### DIFF
--- a/roles/node_health/tasks/main.yml
+++ b/roles/node_health/tasks/main.yml
@@ -1,69 +1,61 @@
 ---
 - name: Gather facts
-  setup:
+  ansible.builtin.setup:
 
-- name: Collect disk usage
-  command: "df -P -x squashfs -x tmpfs -x devtmpfs"
-  register: disk_df
-  changed_when: false
-
-- name: Parse loadavg
-  slurp:
-    src: /proc/loadavg
-  register: loadavg_raw
-  changed_when: false
 
 - name: Compute thresholds
-  set_fact:
-    cpu_cores: "{{ ansible_facts.processor_vcpus | default(ansible_facts.processor_count|default(1)) }}"
-    max_load: "{{ (health_max_load_per_core | float) * (ansible_facts.processor_vcpus | default(ansible_facts.processor_count|default(1))) | float }}"
+  ansible.builtin.set_fact:
+    node_health_cpu_cores: "{{ ansible_facts.processor_vcpus | default(ansible_facts.processor_count | default(1)) }}"
+    node_health_max_load: >-
+      {{ (health_max_load_per_core | float) *
+         (ansible_facts.processor_vcpus | default(ansible_facts.processor_count | default(1))) | float }}
 
 - name: Build report
-  vars:
-    load_line: "{{ (loadavg_raw['content'] | b64decode).split()[0] | float }}"
-  set_fact:
-    health_report:
+  ansible.builtin.set_fact:
+    node_health_report:
       host: "{{ inventory_hostname }}"
       os: "{{ ansible_facts.distribution }} {{ ansible_facts.distribution_version }}"
       uptime: "{{ ansible_facts.uptime_seconds | int }}"
-      cpu_cores: "{{ cpu_cores }}"
-      load1: "{{ load_line }}"
-      load_ok: "{{ load_line | float <= max_load | bool }}"
+      cpu_cores: "{{ node_health_cpu_cores }}"
+      load1: "{{ ansible_loadavg['1'] }}"
+      load_ok: "{{ ansible_loadavg['1'] | float <= node_health_max_load | bool }}"
       mem_mb_total: "{{ ansible_facts.memtotal_mb }}"
       mem_mb_free: "{{ ansible_facts.memfree_mb }}"
-      mem_free_pct: "{{ (ansible_facts.memfree_mb / (ansible_facts.memtotal_mb|float)) * 100.0 }}"
-      disks_raw: "{{ disk_df.stdout_lines }}"
+      mem_free_pct: "{{ (ansible_facts.memfree_mb / (ansible_facts.memtotal_mb | float)) * 100.0 }}"
+      mounts: "{{ ansible_mounts }}"
       time: "{{ ansible_date_time.iso8601 }}"
 
 - name: Summarize and print
-  debug:
+  ansible.builtin.debug:
     msg:
-      - "Host: {{ health_report.host }} ({{ health_report.os }})"
-      - "CPU cores: {{ health_report.cpu_cores }}, Load1: {{ health_report.load1 }} (<= {{ max_load | round(2) }} ok? {{ health_report.load_ok }})"
-      - "Mem: {{ health_report.mem_mb_free }} / {{ health_report.mem_mb_total }} MB ({{ health_report.mem_free_pct | round(1) }}% free)"
-      - "Disks (df -P):"
-      - "{{ health_report.disks_raw }}"
+      - "Host: {{ node_health_report.host }} ({{ node_health_report.os }})"
+      - >-
+        CPU cores: {{ node_health_report.cpu_cores }}, Load1: {{ node_health_report.load1 }}
+        (<= {{ node_health_max_load | round(2) }} ok? {{ node_health_report.load_ok }})
+      - "Mem: {{ node_health_report.mem_mb_free }} / {{ node_health_report.mem_mb_total }} MB ({{ node_health_report.mem_free_pct | round(1) }}% free)"
+      - "Mounts:"
+      - "{{ node_health_report.mounts }}"
 
-- name: service facts
-  service_facts:
+- name: Service facts
+  ansible.builtin.service_facts:
 
 - name: Report service states (ssh, cron)
   vars:
     critical_services:
       - ssh
       - cron
-  debug:
+  ansible.builtin.debug:
     msg: >-
       {{
         critical_services | map('extract', ansible_facts.services) | list
       }}
 
 - name: Post webhook with report
-  uri:
+  ansible.builtin.uri:
     url: "{{ health_alert_webhook }}"
     method: POST
     status_code: 200,204
     body_format: json
-    body: "{{ {'host': inventory_hostname, 'report': health_report} }}"
+    body: "{{ {'host': inventory_hostname, 'report': node_health_report} }}"
   when: health_alert_webhook | length > 0
   changed_when: false


### PR DESCRIPTION
## Summary
- gather load and disk metrics from Ansible facts instead of shelling out
- prefix role variables and use FQCNs for modules

## Testing
- `ansible-lint roles/node_health/tasks/main.yml`


------
https://chatgpt.com/codex/tasks/task_b_68c6c1b9bf9c832291f3d7c7b0cd6daa