### PR TITLE
Refactor ipset management and node health roles

### DIFF
--- a/playbooks/sec_firewall_ipset_setup.yml
+++ b/playbooks/sec_firewall_ipset_setup.yml
@@ -1,6 +1,8 @@
 - name: Prepare ban infrastructure
   hosts: all
   become: true
+  collections:
+    - community.general
   vars:
     ban_time: 3600
   tasks:
@@ -29,7 +31,11 @@
         - ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux", "Suse"]
 
     - name: Ensure banlist set exists
-      command: ipset create banlist hash:ip timeout {{ ban_time }} -exist
+      community.general.ipset:
+        name: banlist
+        state: present
+        set_type: hash:ip
+        timeout: "{{ ban_time }}"
 
     - name: Ensure drop rule via banlist exists (iptables/nft)
       shell: |
@@ -103,3 +109,4 @@
         name: firewall-restore.service
         enabled: true
         state: started
+        daemon_reload: true

--- a/playbooks/sec_ipset_ban_ip.yml
+++ b/playbooks/sec_ipset_ban_ip.yml
@@ -1,12 +1,22 @@
 - name: Ban IP on all servers
   hosts: all
   become: true
+  collections:
+    - community.general
   vars:
     ban_ip: "1.2.3.4"
     ban_time: 3600
   tasks:
     - name: Ensure banlist exists with desired timeout
-      command: ipset create banlist hash:ip timeout {{ ban_time }} -exist
+      community.general.ipset:
+        name: banlist
+        state: present
+        set_type: hash:ip
+        timeout: "{{ ban_time }}"
 
     - name: Add IP with timeout (auto-expires)
-      command: ipset add banlist {{ ban_ip }} timeout {{ ban_time }} -exist
+      community.general.ipset:
+        name: banlist
+        state: present
+        entry: "{{ ban_ip }}"
+        timeout: "{{ ban_time }}"

--- a/playbooks/sec_ipset_ban_list.yml
+++ b/playbooks/sec_ipset_ban_list.yml
@@ -1,6 +1,8 @@
 - name: Add IPs or networks to banlist
   hosts: all
   become: true
+  collections:
+    - community.general
   vars:
     ban_list_raw: ""    # вводится через Survey: "1.2.3.4, 10.0.0.0/8"
     ban_time: 3600      # время в секундах (также через Survey)
@@ -10,7 +12,11 @@
         ban_list: "{{ ban_list_raw.split(',') | map('trim') | reject('equalto','') | list }}"
 
     - name: Add each IP or network to banlist
+      community.general.ipset:
+        name: banlist
+        state: present
+        entry: "{{ item }}"
+        timeout: "{{ ban_time }}"
       loop: "{{ ban_list }}"
       loop_control:
         label: "{{ item }}"
-      command: ipset add banlist {{ item }} timeout {{ ban_time }} -exist

--- a/playbooks/sec_ipset_unban_ip.yml
+++ b/playbooks/sec_ipset_unban_ip.yml
@@ -1,11 +1,18 @@
 - name: Unban IP on all servers
   hosts: all
   become: yes
+  collections:
+    - community.general
   vars:
     ban_ip: "1.2.3.4"   # передашь через extra vars в шаблоне
   tasks:
     - name: Remove IP from banlist if present
-      shell: ipset del banlist {{ ban_ip }} || true
-- name: Save ipset to file
-  become: true
-  shell: ipset save > /etc/ipset.rules
+      community.general.ipset:
+        name: banlist
+        entry: "{{ ban_ip }}"
+        state: absent
+
+    - name: Save ipset to file
+      shell: ipset save > /etc/ipset.rules
+      changed_when: false
+      become: true

--- a/roles/firewall_ipset/tasks/main.yml
+++ b/roles/firewall_ipset/tasks/main.yml
@@ -7,13 +7,11 @@
   become: true
 
 - name: Create ipset (idempotent)
-  command: "ipset create {{ fw_ipset_name }} hash:ip timeout {{ fw_ipset_timeout }}"
-  args:
-    warn: false
-  register: ipset_create
-  changed_when: "'created' in ipset_create.stderr or ipset_create.rc == 0"
-  failed_when: ipset_create.rc not in [0,1] and ('Set cannot be created' not in ipset_create.stderr)
-  ignore_errors: true
+  community.general.ipset:
+    name: "{{ fw_ipset_name }}"
+    state: present
+    set_type: hash:ip
+    timeout: "{{ fw_ipset_timeout }}"
   become: true
 
 - name: Ensure firewall base allow for SSH from trusted subnets
@@ -83,4 +81,5 @@
         name: firewall-restore.service
         enabled: true
         state: started
+        daemon_reload: true
       become: true

--- a/roles/node_health/tasks/main.yml
+++ b/roles/node_health/tasks/main.yml
@@ -3,15 +3,8 @@
   setup:
 
 - name: Collect disk usage
-  command: "df -P -x squashfs -x tmpfs -x devtmpfs"
-  register: disk_df
-  changed_when: false
-
-- name: Parse loadavg
-  slurp:
-    src: /proc/loadavg
-  register: loadavg_raw
-  changed_when: false
+  set_fact:
+    disk_info: "{{ ansible_mounts }}"
 
 - name: Compute thresholds
   set_fact:
@@ -19,20 +12,18 @@
     max_load: "{{ (health_max_load_per_core | float) * (ansible_facts.processor_vcpus | default(ansible_facts.processor_count|default(1))) | float }}"
 
 - name: Build report
-  vars:
-    load_line: "{{ (loadavg_raw['content'] | b64decode).split()[0] | float }}"
   set_fact:
     health_report:
       host: "{{ inventory_hostname }}"
       os: "{{ ansible_facts.distribution }} {{ ansible_facts.distribution_version }}"
       uptime: "{{ ansible_facts.uptime_seconds | int }}"
       cpu_cores: "{{ cpu_cores }}"
-      load1: "{{ load_line }}"
-      load_ok: "{{ load_line | float <= max_load | bool }}"
+      load1: "{{ ansible_loadavg['1'] }}"
+      load_ok: "{{ ansible_loadavg['1'] | float <= max_load | bool }}"
       mem_mb_total: "{{ ansible_facts.memtotal_mb }}"
       mem_mb_free: "{{ ansible_facts.memfree_mb }}"
       mem_free_pct: "{{ (ansible_facts.memfree_mb / (ansible_facts.memtotal_mb|float)) * 100.0 }}"
-      disks_raw: "{{ disk_df.stdout_lines }}"
+      disks_raw: "{{ disk_info }}"
       time: "{{ ansible_date_time.iso8601 }}"
 
 - name: Summarize and print
@@ -41,7 +32,7 @@
       - "Host: {{ health_report.host }} ({{ health_report.os }})"
       - "CPU cores: {{ health_report.cpu_cores }}, Load1: {{ health_report.load1 }} (<= {{ max_load | round(2) }} ok? {{ health_report.load_ok }})"
       - "Mem: {{ health_report.mem_mb_free }} / {{ health_report.mem_mb_total }} MB ({{ health_report.mem_free_pct | round(1) }}% free)"
-      - "Disks (df -P):"
+      - "Disks:"
       - "{{ health_report.disks_raw }}"
 
 - name: service facts


### PR DESCRIPTION
## Summary
- switch ipset playbooks to dedicated module
- ensure firewall-restore unit reloads systemd
- replace shell metrics collection with Ansible facts

## Testing
- `ansible-playbook --syntax-check playbooks/sec_ipset_ban_ip.yml` *(fails: couldn't resolve module 'community.general.ipset')*
- `ansible-playbook --syntax-check playbooks/sec_ipset_ban_list.yml` *(fails: couldn't resolve module 'community.general.ipset')*
- `ansible-playbook --syntax-check playbooks/sec_ipset_unban_ip.yml` *(fails: couldn't resolve module 'community.general.ipset')*
- `ansible-playbook --syntax-check playbooks/sec_firewall_ipset_setup.yml` *(fails: couldn't resolve module 'community.general.ipset')*
- `ansible-playbook --syntax-check playbooks/17_node_health.yml`


------
https://chatgpt.com/codex/tasks/task_b_68c6bfd52fec832285b0b64b2698fc8b