### PR TITLE
Handle existing ipset during ban

### DIFF
--- a/playbooks/sec_ipset_ban_ip.yml
+++ b/playbooks/sec_ipset_ban_ip.yml
@@ -5,11 +5,17 @@
     ban_ip: "1.2.3.4"
     ban_time: 3600
   tasks:
+    - name: Check for existing banlist
+      command: ipset list banlist
+      register: ipset_check
+      changed_when: false
+      failed_when: false
+
     - name: Ensure banlist exists with desired timeout
-      command: ipset create banlist hash:ip timeout {{ ban_time }} -exist
+      command: ipset create banlist hash:ip timeout {{ ban_time }}
+      when: ipset_check.rc != 0
       register: ipset_create
-      changed_when: "'created' in ipset_create.stderr or ipset_create.rc == 0"
-      failed_when: ipset_create.rc not in [0,1] and ('Set cannot be created' not in ipset_create.stderr)
+      changed_when: ipset_create.rc == 0
 
     - name: Add IP with timeout (auto-expires)
       command: ipset add banlist {{ ban_ip }} timeout {{ ban_time }} -exist

--- a/playbooks/sec_ipset_ban_ip.yml
+++ b/playbooks/sec_ipset_ban_ip.yml
@@ -5,17 +5,11 @@
     ban_ip: "1.2.3.4"
     ban_time: 3600
   tasks:
-    - name: Check for existing banlist
-      command: ipset list banlist
-      register: ipset_check
-      changed_when: false
-      failed_when: false
-
     - name: Ensure banlist exists with desired timeout
-      command: ipset create banlist hash:ip timeout {{ ban_time }}
-      when: ipset_check.rc != 0
+      command: ipset -exist create banlist hash:ip timeout {{ ban_time }}
       register: ipset_create
-      changed_when: ipset_create.rc == 0
+      changed_when: ipset_create.rc == 0 and 'already exists' not in ipset_create.stderr|lower
+      failed_when: ipset_create.rc != 0 and 'already exists' not in ipset_create.stderr|lower
 
     - name: Add IP with timeout (auto-expires)
       command: ipset add banlist {{ ban_ip }} timeout {{ ban_time }} -exist

--- a/playbooks/sec_ipset_ban_ip.yml
+++ b/playbooks/sec_ipset_ban_ip.yml
@@ -7,6 +7,9 @@
   tasks:
     - name: Ensure banlist exists with desired timeout
       command: ipset create banlist hash:ip timeout {{ ban_time }} -exist
+      register: ipset_create
+      changed_when: "'created' in ipset_create.stderr or ipset_create.rc == 0"
+      failed_when: ipset_create.rc not in [0,1] and ('Set cannot be created' not in ipset_create.stderr)
 
     - name: Add IP with timeout (auto-expires)
       command: ipset add banlist {{ ban_ip }} timeout {{ ban_time }} -exist


### PR DESCRIPTION
## Summary
- make ipset ban IP playbook resilient to existing sets

## Testing
- `ansible-playbook playbooks/sec_ipset_ban_ip.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_b_68c6c8d3ba608322bfb61f420d5d7014